### PR TITLE
fix: cleaning google dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,7 @@
         "symfony/polyfill-php81": "*"
     },
     "scripts": {
+        "pre-autoload-dump": "Google\\Task\\Composer::cleanup",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
@@ -105,7 +106,10 @@
         "symfony": {
             "allow-contrib": false,
             "require": "6.1.*"
-        }
+        },
+        "google/apiclient-services": [
+            "YouTube"
+        ]
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
J'ai ajouté quelques lignes dans le composer.json afin de nettoyer les différentes dépendances googles qui ne sont pas utiles au projet.

Les explications sont directement lié au SDK fournis par google : https://github.com/googleapis/google-api-php-client#cleaning-up-unused-services

Ajuster au besoin, les dépendances à garder sur 
`"google/apiclient-services": [
            "YouTube"
   ]`